### PR TITLE
platform specific dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cgmath = "0.17.0"
 image = "0.23.0"
 
 
-[target.'cfg(macos)'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
 libc = "0.2"
 cocoa = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ shaderc = "0.6"
 memoffset = "0.5"
 cgmath = "0.17.0"
 image = "0.23.0"
+
+
+[target.'cfg(macos)'.dependencies]
 objc = "0.2"
 libc = "0.2"
 cocoa = "0.19.0"


### PR DESCRIPTION
the macos deps don't compile for linux

@rag594 Not sure if this cfg works for macos, please check and update if necessary

Reference:
https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies